### PR TITLE
Update chiptest.8o

### DIFF
--- a/chiptest.8o
+++ b/chiptest.8o
@@ -413,7 +413,7 @@
 	v2 := 0x3
 	v1 <<= v2
 	i := failed
-	if v1 == 0x4 then i := passed
+	if v1 == 0x6 then i := passed
 	vd := 60
 	print_r4
 


### PR DESCRIPTION
Fixed the 8XYE test as shifting 0x03 to the left actually gives 0x06 (or multiplies it by 2).